### PR TITLE
Fix for uploading a dSYM file

### DIFF
--- a/src/Cake.HockeyApp/HockeyAppAliases.cs
+++ b/src/Cake.HockeyApp/HockeyAppAliases.cs
@@ -130,7 +130,7 @@
         [CakeAliasCategory("Deployment")]
         [CakeMethodAlias]
         public static HockeyAppUploadResult UploadToHockeyApp(this ICakeContext context, FilePath file, FilePath symbolsFile)
-            => UploadToHockeyApp(context, file, null, new HockeyAppUploadSettings());
+            => UploadToHockeyApp(context, file, symbolsFile, new HockeyAppUploadSettings());
 
         /// <summary>
         /// Uploads the specified package to HockeyApp. Currently it is required to specify the AppId and the

--- a/src/Cake.HockeyApp/Internal/HockeyAppClient.cs
+++ b/src/Cake.HockeyApp/Internal/HockeyAppClient.cs
@@ -101,13 +101,13 @@ namespace Cake.HockeyApp.Internal
 
             if (symbolFile != null)
             {
-                var isSupportedSymbols = symbolFile.FullPath.EndsWith(".dsym.zip")
+                var isSupportedSymbols = symbolFile.FullPath.EndsWith(".dSYM.zip")
                 || symbolFile.FullPath.EndsWith("mapping.txt");
 
                 if (!isSupportedSymbols)
                 {
                     throw new ArgumentException(
-                        "Symbols file needs to be of the following type: *.dsym.zip for iOS / OS X, or mapping.txt file for Android.",
+                        "Symbols file needs to be of the following type: *.dSYM.zip for iOS / OS X, or mapping.txt file for Android.",
                         nameof(symbolFile));
                 }
             }


### PR DESCRIPTION
This fixes uploading with:
```
UploadToHockeyApp(ICakeContext, FilePath, FilePath)
```
And corrects the file extension check.