### PR TITLE
Changed base URL for faster uploads

### DIFF
--- a/src/Cake.HockeyApp/Internal/HockeyAppClient.cs
+++ b/src/Cake.HockeyApp/Internal/HockeyAppClient.cs
@@ -7,7 +7,7 @@ namespace Cake.HockeyApp.Internal
 
     internal class HockeyAppClient
     {
-        private const string HockeyAppBaseUrl = "https://rink.hockeyapp.net";
+        private const string HockeyAppBaseUrl = "https://upload.hockeyapp.net"; // Only suitable for PUT/POST, use rink.hockeyapp.net for GET
 
         private readonly HockeyAppApiClient _client;
         private readonly ICakeLog _log;


### PR DESCRIPTION
Using upload.hockeyapp.net instead of rink.hockeyapp.net when uploading binaries can give significantly faster upload times. The former is based on Amazon CloudFront CDN. It is a supported alternative for create/update REST endpoints according to https://support.hockeyapp.net/discussions/problems/33355-is-uploadhockeyappnet-available-for-general-use

For example, uploading a 75 MB UWP .zip package from where I'm located is at least 5x faster (seconds instead of minutes) after this change.

It works for all requests right now since all the addin does is uploads. If #2  is ever to be implemented, then one would have to pick the right base URL (rink. for queries) depending on usage. 