### PR TITLE
Fix for UploadToVersion failing for symbols

### DIFF
--- a/src/Cake.HockeyApp/Internal/HockeyAppApiClient.cs
+++ b/src/Cake.HockeyApp/Internal/HockeyAppApiClient.cs
@@ -60,12 +60,12 @@
             request.AddIfNotEmpty("repository_url", repositoryUrl);
 
             appStream = File.OpenRead(filePath);
-            request.Add(new StreamContent(appStream), "ipa", Path.GetFileName(filePath));
+            request.AddIfNotEmpty("ipa", Path.GetFileName(filePath), appStream);
 
             if (!string.IsNullOrEmpty(symbolPath))
             {
                 dsymStream = File.OpenRead(symbolPath);
-                request.Add(new StreamContent(dsymStream), "dsym", Path.GetFileName(filePath));
+                request.AddIfNotEmpty("dsym", Path.GetFileName(symbolPath), dsymStream);
             }
 
             var httpResponse = await _restClient.PutAsync($"/api/2/apps/{appId}/app_versions/{version}", request);


### PR DESCRIPTION
I had problems uploading a Windows UWP .appx binary package along with its .appxsym debug symbol file. It kept failing with HTTP 422 and error message 

> Bundle version could not be determined. Please check your meta data and make sure that the bundle identifier matches the value on HockeyApp.

I traced it down to have the same root cause as in #14 so I have not created a new issue for it. The solution is the same, to use request.AddIfNotEmpty extension method instead of plain request.Add. This PR makes the handling of files in HockeyAppApiClient.UploadFileToVersionAsync identical to UploadFileAsync. 

Also, the file name sent with the debug symbols was incorrectly derived from filePath instead of symbolPath.
